### PR TITLE
feat: add sets and reps support to workout recommendation plan

### DIFF
--- a/EEP/.env
+++ b/EEP/.env
@@ -7,4 +7,4 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgresql://user:pass@postgres:5432/trainmeai
 
 IEP1_URL=http://iep1:8001/api/v1/pose
-IEP2_URL=http://iep-2-service:8000/api/v1
+IEP2_URL=http://iep2:8000/api/v1

--- a/EEP/pages/Dashboard.py
+++ b/EEP/pages/Dashboard.py
@@ -12,7 +12,7 @@ st.set_page_config(
 )
 
 load_sidebar()
-st.title("📊 Dashboard")
+st.markdown("<h1 style='color:#1664AD;'>📊 Dashboard</h1>", unsafe_allow_html=True)
 
 # --- ENV CONFIG ---
 IEP2_URL = os.getenv("IEP2_URL", "http://localhost:8002")  # Fallback for local dev

--- a/IEP2/app/api/v1/endpoints.py
+++ b/IEP2/app/api/v1/endpoints.py
@@ -63,7 +63,23 @@ def recommend_workout_plan(data: RecommendRequest):
                 goals=",".join(exercise["goals"]),
             )
             db.add(ex_item)
-            plan.append(ExerciseItem(**exercise))
+            sets = 3
+            reps = 12
+            if data.fitness_level == "beginner":
+                sets, reps = 2, 10
+            elif data.fitness_level == "intermediate":
+                sets, reps = 3, 12
+            elif data.fitness_level == "advanced":
+                sets, reps = 4, 15
+
+            plan.append(ExerciseItem(
+                name=exercise["name"],
+                category=exercise["category"],
+                difficulty=exercise["difficulty"],
+                goals=exercise["goals"],
+                sets=sets,
+                reps=reps
+            ))            
             seen.add(exercise["name"])
 
         if done:

--- a/IEP2/app/api/v1/schemas.py
+++ b/IEP2/app/api/v1/schemas.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 from pydantic import BaseModel, Field
 
 
@@ -15,6 +15,8 @@ class ExerciseItem(BaseModel):
     difficulty: str
     goals: List[str]
     feedback_rating: Optional[float] = None
+    sets: int
+    reps: int
 
 
 class RecommendResponse(BaseModel):
@@ -27,6 +29,6 @@ class FeedbackRequest(BaseModel):
     exercise_name: str
     category: str
     difficulty: str
-    rating: float = Field(..., ge=1.0, le=5.0)
+    rating: Union[int, str]
     exercise_completed: bool = False
     time_spent: float = Field(..., ge=0.0)

--- a/IEP3/.env
+++ b/IEP3/.env
@@ -7,4 +7,4 @@ POSTGRES_PORT=5432
 DATABASE_URL=postgresql://user:pass@postgres:5432/trainmeai
 
 IEP1_URL=http://iep1:8001/api/v1/pose
-IEP2_URL=http://iep-2-service:8000/api/v1
+IEP2_URL=http://iep2:8000/api/v1


### PR DESCRIPTION
This PR includes:
- Support for sets and reps per exercise in the personalized workout recommendation flow
- Updated the ExerciseItem Pydantic model to include sets and reps fields
- Dynamically generated sets and reps based on the user's fitness level in the /recommend endpoint logic

