### PR TITLE
feat: support monitoring using grafana and prometheus

### DIFF
--- a/IEP3/main.py
+++ b/IEP3/main.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel,conlist
 from typing import List,Optional
 import pandas as pd
 from model import recommend,output_recommended_recipes
+from prometheus_fastapi_instrumentator import Instrumentator
 
 
 dataset=pd.read_csv('data/dataset.csv',compression='gzip')
@@ -117,3 +118,5 @@ def get_goal_based_plan(req: GoalRequest):
         "name", "prep_time", "cook_time", "total_time",
         "ingredients", "instructions", "protein", "sugar", "fiber", "calories"
     ]].to_dict(orient="records")
+
+instrumentator = Instrumentator().instrument(app).expose(app)

--- a/IEP3/requirements.txt
+++ b/IEP3/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.24.1
 scikit-learn==1.1.3
 pandas==1.5.1
 pydantic==1.10.4
+prometheus_fastapi_instrumentator==7.1.0

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
   TrainMeAI
 </h1>
 
-**TrainMeAI** is an advanced AI-powered fitness platform designed to deliver personalized workout recommendations, real-time exercise form analysis, and intelligent meal planning. Leveraging state-of-the-art reinforcement learning, computer vision, and nutritional intelligence, TrainMeAI dynamically adapts to individual user needs—whether they are fitness novices or experienced athletes—offering a comprehensive and tailored approach to health and wellness.
 
-**TrainMeAI** is an AI-powered fitness platform designed to deliver personalized workout recommendations, real-time exercise form analysis, and intelligent meal planning. By integrating reinforcement learning, computer vision, and machine learning, it continuously adapts to each user’s fitness level, goals, and preferences.
+**TrainMeAI** is an AI-powered fitness platform designed to deliver personalized workout recommendations, real-time exercise form analysis, and intelligent meal planning. By integrating reinforcement learning, computer vision, and machine learning, TrainMeAI dynamically adapts to individual user needs—whether they are fitness beginners or experienced athletes—offering a comprehensive and tailored approach to health and wellness.
 
 # Features
 
@@ -79,20 +78,44 @@ The TrainMeAI platform was deployed using a containerized microservices architec
 - **Kubernetes Secrets** are used for secure storage of sensitive data such as database URLs and API keys.
 - **ConfigMaps** store service-specific environment variables and runtime configurations.
 
-### Monitoring and Observability
-
-- **Prometheus** collects metrics from each IEP and the frontend.
-- **Grafana** visualizes service performance, including:
-  - Inference latency
-  - Recommendation accuracy
-  - API health and usage metrics
-
 ### Service Communication
 
 - All services communicate via internal service names in AKS using `ClusterIP` networking.
 - No direct communication occurs between AI modules—communication flows only through API requests initiated by the frontend (EEP).
 
 
+## Monitoring and Observability
+
+TrainMeAI includes a full observability stack powered by **Prometheus** and **Grafana** to monitor the health and performance of all intelligent services (IEPs and EEP).
+
+- **Prometheus** collects metrics from each IEPs and the frontend.
+- **Grafana** visualizes service performance
+
+### Metrics tracked
+                                           
+    | Total number of HTTP requests                    
+    | Requests per second (RPS)                        
+    | Latency histogram with p95 duration          
+    | Real-time memory usage                       
+    | CPU usage per container                      
+    | Uptime since the container started            
+
+### Viewing the Dashboard (Locally)
+1- After running docker-compose.yaml, open Grafana in your browser:
+  http://localhost:3000
+
+2. Login using default credentials:
+- **Username**: `admin`
+- **Password**: `admin`
+
+3. Go to **“+ → Import”**
+4. Upload the dashboard JSON file from the [Shared Folder](https://drive.google.com/file/d/1mI9d-6bjJSsqCOKwYUGJ2l11w8t6NpnF/view)
+
+
+5. Select your Prometheus data source and click **Import**
+
+
 # Resources
-https://drive.google.com/drive/folders/1opgEii5W0dIYtCmPPjr66w7nCjJ_FWEl?q=sharedwith:public%20parent:1opgEii5W0dIYtCmPPjr66w7nCjJ_FWEl
+Additional relevant data can bbe found in a 
+[Shared folder](https://drive.google.com/drive/folders/1opgEii5W0dIYtCmPPjr66w7nCjJ_FWEl?q=sharedwith:public%20parent:1opgEii5W0dIYtCmPPjr66w7nCjJ_FWEl)
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,5 +57,23 @@ services:
       - postgres
     ports:
       - 8002:8002
+  
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-storage:/var/lib/grafana
+
 volumes:
   pgdata:
+  grafana-storage:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: 'iep3'
+    static_configs:
+      - targets: ['iep3:8002']
+


### PR DESCRIPTION
This PR adds monitoring for TrainMeAI and includes the following changes:

- Exposing Prometheus metrics in IEP3 (main.py) using prometheus_fastapi_instrumentator
- Adding Prometheus and Grafana services via Docker Compose
- Creating a Grafana dashboard for IEP3 metrics
- Update readme file to include monitoring setup and description 